### PR TITLE
feat(web): add FlSerial.requestPort() to pre-request permission without opening

### DIFF
--- a/lib/src/flserial_native.dart
+++ b/lib/src/flserial_native.dart
@@ -309,4 +309,10 @@ class FlSerial {
   static Future<List<SerialPortInfo>> availablePorts() async {
     return SerialScanner.getAvailablePorts();
   }
+
+  /// No-op on native (always returns `null`) — kept for API parity with the
+  /// web implementation, where it requests Web Serial permission via the
+  /// browser's picker without opening the port. Native ports never require
+  /// prior permission, so just call [availablePorts] and [open] directly.
+  static Future<SerialPortInfo?> requestPort() async => null;
 }

--- a/lib/src/flserial_web_impl.dart
+++ b/lib/src/flserial_web_impl.dart
@@ -36,6 +36,13 @@ export 'serial_types.dart';
 /// `web:request`. Passing it to [open] triggers `navigator.serial.requestPort()`
 /// which shows the browser's native device-picker dialog. This requires a
 /// user gesture — a button tap qualifies.
+///
+/// To ask for permission ahead of time and open the port later (e.g. to
+/// keep a "Connect" button and a "Read" action separate, without prompting
+/// again for every reconnect), call [requestPort] instead — it shows the
+/// same picker but doesn't open the port, returning a [SerialPortInfo]
+/// whose [SerialPortInfo.path] you can pass to [open] whenever you're
+/// ready, with no picker shown again.
 class FlSerial {
   final _eventController = StreamController<SerialEvent>.broadcast();
 
@@ -133,4 +140,23 @@ class FlSerial {
   /// `web:request`. Passing that path to [open] shows the browser picker.
   static Future<List<SerialPortInfo>> availablePorts() =>
       SerialScanner.getAvailablePorts();
+
+  /// Requests permission for a port via the browser's native device-picker
+  /// dialog, **without opening it**.
+  ///
+  /// Requires a user gesture (e.g. a button tap). Pass the returned
+  /// [SerialPortInfo.path] to [open] later — since permission was already
+  /// granted here, that won't show the picker again.
+  ///
+  /// Returns `null` if the user cancels the picker or denies permission.
+  ///
+  /// No-op on native (always returns `null`) — kept for API parity so
+  /// shared code doesn't need to branch on `kIsWeb`; native ports never
+  /// require prior permission, so just call [availablePorts] and [open]
+  /// directly there.
+  static Future<SerialPortInfo?> requestPort() async {
+    final desc = await requestWebPort();
+    if (desc == null) return null;
+    return SerialPortInfo(desc.path, desc.description);
+  }
 }

--- a/lib/src/web_serial.dart
+++ b/lib/src/web_serial.dart
@@ -75,6 +75,42 @@ typedef WebPortDesc = ({String path, String description});
 
 final _portCache = <String, SerialPort>{};
 
+int _nextRequestedPortId = 0;
+
+/// Requests permission for a port via the browser's native device-picker
+/// dialog, **without opening it**.
+///
+/// Requires a user gesture (e.g. a button tap). The returned path is cached
+/// in [_portCache], so a later [openWebPort] call for it resolves
+/// immediately without prompting again — unlike opening the `web:request`
+/// sentinel path, which always fuses the prompt and the open into one step.
+///
+/// Returns `null` if the user cancels the picker or permission is denied.
+Future<WebPortDesc?> requestWebPort() async {
+  final s = _serial;
+  if (s == null) return null;
+
+  final SerialPort port;
+  try {
+    port = await s.requestPort().toDart;
+  } catch (_) {
+    // The picker rejects its promise (rather than resolving null) when the
+    // user cancels or denies permission.
+    return null;
+  }
+
+  final path = 'web:requested:${_nextRequestedPortId++}';
+  _portCache[path] = port;
+  final info = port.getInfo();
+  final vid = info.usbVendorId;
+  final pid = info.usbProductId;
+  final desc = (vid != null && pid != null)
+      ? 'VID:${vid.toRadixString(16).padLeft(4, '0').toUpperCase()} '
+        'PID:${pid.toRadixString(16).padLeft(4, '0').toUpperCase()}'
+      : 'Web Serial Device';
+  return (path: path, description: desc);
+}
+
 Future<List<WebPortDesc>> listWebPorts() async {
   final s = _serial;
   if (s == null) return [];

--- a/lib/src/web_serial_stub.dart
+++ b/lib/src/web_serial_stub.dart
@@ -5,6 +5,8 @@ bool get webSerialAvailable => false;
 
 typedef WebPortDesc = ({String path, String description});
 
+Future<WebPortDesc?> requestWebPort() async => null;
+
 Future<List<WebPortDesc>> listWebPorts() async => [];
 
 Future<bool> openWebPort(


### PR DESCRIPTION
## Problem

`navigator.serial.requestPort()` — the browser's native device-picker
dialog — is currently only reachable through `open()`'s `web:request`
sentinel path, which fuses the permission prompt and opening the port into
a single call. Apps that want to ask for port access once (e.g. an explicit
"Connect" button) and then open/close/reconnect afterward have no way to
do that without showing the picker again on every `open()` call.

## Change

Adds `FlSerial.requestPort()` (static, matching `availablePorts()`'s
shape): shows the same device picker but does **not** open the port.
Returns a `SerialPortInfo` whose `path` can be passed to `open()` later —
since permission was already granted, that call resolves immediately with
no picker shown.

```dart
final requested = await FlSerial.requestPort(); // prompts, doesn't open
if (requested == null) return; // user cancelled

final port = FlSerial();
await port.open(requested.path, SerialConfig(baudRate: 9600)); // no prompt