### PR TITLE
fix(web): remove malformed pluginClass:none web platform declaration

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,18 +9,6 @@ flutter:
       android:
         package: io.github.grzesl.flserial
         pluginClass: FlserialPlugin
-      # No web entry here on purpose: Flutter's web-plugin codegen only
-      # skips `pluginClass: none` when it's paired with a `dartPluginClass`
-      # (its federated-plugin registration mechanism). Without one,
-      # `_writeWebPluginRegistrant` (flutter_tools/lib/src/flutter_plugins.dart)
-      # includes the plugin unconditionally and emits
-      # `none.registerWith(registrar)`, treating the literal string "none" as
-      # an import prefix -- breaking `flutter build web` with
-      # "'Registrar' isn't a type" / "Undefined name 'none'" in any app that
-      # depends on this package. The web implementation
-      # (lib/src/flserial_web_impl.dart) is pure dart:js_interop and never
-      # needed plugin registration in the first place, so dropping the `web:`
-      # platform entry entirely is a correct, no-op-equivalent fix.
 
 environment:
   sdk: ^3.11.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,9 +9,18 @@ flutter:
       android:
         package: io.github.grzesl.flserial
         pluginClass: FlserialPlugin
-      web:
-        pluginClass: none
-        fileName: flserial.dart
+      # No web entry here on purpose: Flutter's web-plugin codegen only
+      # skips `pluginClass: none` when it's paired with a `dartPluginClass`
+      # (its federated-plugin registration mechanism). Without one,
+      # `_writeWebPluginRegistrant` (flutter_tools/lib/src/flutter_plugins.dart)
+      # includes the plugin unconditionally and emits
+      # `none.registerWith(registrar)`, treating the literal string "none" as
+      # an import prefix -- breaking `flutter build web` with
+      # "'Registrar' isn't a type" / "Undefined name 'none'" in any app that
+      # depends on this package. The web implementation
+      # (lib/src/flserial_web_impl.dart) is pure dart:js_interop and never
+      # needed plugin registration in the first place, so dropping the `web:`
+      # platform entry entirely is a correct, no-op-equivalent fix.
 
 environment:
   sdk: ^3.11.3


### PR DESCRIPTION
Fixes #13
## Problem

`flutter build web` fails for any app depending on this package:

```
error: 'Registrar' isn't a type
error: Undefined name 'webPluginRegistrar'
error: Undefined name 'none'
```

## Cause

`pubspec.yaml`'s `web:` platform entry declares `pluginClass: none` without a paired `dartPluginClass`. That combination is only meaningful together — it tells Flutter's web-plugin codegen this is a federated Dart-only plugin registered through a different mechanism, so it should skip generating a method-channel registration call. Declared alone, `_writeWebPluginRegistrant` (`flutter_tools/lib/src/flutter_plugins.dart`) includes the plugin unconditionally and emits `none.registerWith(registrar)`, treating the literal string `"none"` as an import prefix.

## This is a regression

Web support worked correctly in **v0.7.0** (no `web:` platform entry at all). **v0.7.1** added `web: pluginClass: none` to declare all platforms for completeness — that one-line addition is what broke `flutter build web`, and it's been broken through 0.7.2. `lib/src/flserial_web_impl.dart` is pure `dart:js_interop` and never needed plugin registration, so the `web:` entry shouldn't exist at all.

## Fix

Removes the `web:` platform entry from `pubspec.yaml` entirely — a no-op-equivalent fix, since nothing in the web implementation relies on Flutter's plugin registration mechanism.

## Testing

`flutter clean && flutter pub get && flutter build web` against `example/` — fails before this change, succeeds after.